### PR TITLE
Open subdirectories recursively

### DIFF
--- a/src/plugins/projectexplorer/foldernavigationwidget.cpp
+++ b/src/plugins/projectexplorer/foldernavigationwidget.cpp
@@ -304,6 +304,19 @@ void FolderNavigationWidget::openItem(const QModelIndex &srcIndex, bool openDire
         }
         // Change to directory
         setCurrentDirectory(path);
+        // Find nested entries. If folder contains only one entry and that one is the folder - open it
+        {
+            QDir dir(path);
+            QStringList proFiles;
+            QFileInfoList entries = dir.entryInfoList(QDir::AllEntries);
+            while (entries.size() > 0 && (entries.at(0).fileName() == QLatin1String(".") || entries.at(0).fileName() == QLatin1String("..")))
+                entries.removeAt(0);
+            if (entries.size() == 1 && entries.at(0).isDir()) {
+                const QModelIndex entryIndex = m_fileSystemModel->index(entries.at(0).filePath());
+                // Do not open nested projects automatically
+                openItem(entryIndex, false);
+            }
+        }
         return;
     }
     // Open file.


### PR DESCRIPTION
Just like in IntelliJ Idea: when a directory, namely `Dir` contains only one entry, namely `Sub1` and this entry is a directory, opening `Dir` will open the `Sub1`. 

Here's more detailed explanation: let's assume we have a directory structure like this:

![226](https://cloud.githubusercontent.com/assets/137882/7090862/2c173372-dfa6-11e4-95db-36a86fd91f72.png)

When user will try to open-up the `tmp/` directory, it has no sense to open the `tmp/` dir itself - it's better to open all the tree down to the `baz` dir.