### PR TITLE
ProjectExplorer: Easier session browsing

### DIFF
--- a/src/plugins/projectexplorer/projectexplorer.cpp
+++ b/src/plugins/projectexplorer/projectexplorer.cpp
@@ -3298,7 +3298,9 @@ void ProjectExplorerPluginPrivate::updateSessionMenu()
     QActionGroup *ag = new QActionGroup(m_sessionMenu);
     connect(ag, &QActionGroup::triggered, this, &ProjectExplorerPluginPrivate::setSession);
     const QString activeSession = SessionManager::activeSession();
-    foreach (const QString &session, SessionManager::sessions()) {
+    QStringList ss(SessionManager::sessions());
+    qSort(ss.begin(), ss.end());
+    foreach (QString const & session, ss) {
         QAction *act = ag->addAction(session);
         act->setData(session);
         act->setCheckable(true);

--- a/src/plugins/projectexplorer/projectexplorer.cpp
+++ b/src/plugins/projectexplorer/projectexplorer.cpp
@@ -796,7 +796,7 @@ bool ProjectExplorerPlugin::initialize(const QStringList &arguments, QString *er
 
     // session menu
     ActionContainer *msession = ActionManager::createMenu(Constants::M_SESSION);
-    msession->menu()->setTitle(tr("Sessions"));
+    msession->menu()->setTitle(tr("&Sessions"));
     msession->setOnAllDisabledBehavior(ActionContainer::Show);
     mfile->addMenu(msession, Core::Constants::G_FILE_OPEN);
     dd->m_sessionMenu = msession->menu();

--- a/src/plugins/projectexplorer/sessiondialog.cpp
+++ b/src/plugins/projectexplorer/sessiondialog.cpp
@@ -158,6 +158,7 @@ bool SessionDialog::autoLoadSession() const
 void SessionDialog::addItems(bool setDefaultSession)
 {
     QStringList sessions = SessionManager::sessions();
+    qSort(sessions.begin(), sessions.end());
     foreach (const QString &session, sessions) {
         m_ui.sessionList->addItem(session);
         if (setDefaultSession && session == SessionManager::activeSession())
@@ -186,6 +187,7 @@ void SessionDialog::addSessionToUi(const QString &name, bool switchTo)
 {
     m_ui.sessionList->clear();
     QStringList sessions = SessionManager::sessions();
+    qSort(sessions.begin(), sessions.end());
     m_ui.sessionList->addItems(sessions);
     m_ui.sessionList->setCurrentRow(sessions.indexOf(name));
     markItems();


### PR DESCRIPTION
Hello!

If you have a lot of sessions, it helps to be able to launch Qt Creator, ALT+F, ALT+S, and select the session you want. The first commit implements the ALT+S keyboard accelerator and the second commit sorts the sessions so they're easier to browse.

Do whatever you like with these proposed changes, these are public domain. Yo, whatever! I don't have time to process all the legal rubbish in a Qt collaboration agreement or the TOS for a Qt Account. So don't bother me with it. I will make no legal claims if this is code is accepted into Qt Creator even under somebody elses name as author, or somebody else claiming intellectual property. I just post this for the common good, so go ahead, do whatever you like with these changes.

For Gentoo Linux users, here's a `/etc/portage/patches/dev-qt/qt-creator/qt-creator-sessions-menu.patch` file with the two patches:
```
diff --git a/src/plugins/projectexplorer/projectexplorer.cpp b/src/plugins/projectexplorer/projectexplorer.cpp
index 2657978..314b343 100644
--- a/src/plugins/projectexplorer/projectexplorer.cpp
+++ b/src/plugins/projectexplorer/projectexplorer.cpp
@@ -796,7 +796,7 @@ bool ProjectExplorerPlugin::initialize(const QStringList &arguments, QString *er
 
     // session menu
     ActionContainer *msession = ActionManager::createMenu(Constants::M_SESSION);
-    msession->menu()->setTitle(tr("Sessions"));
+    msession->menu()->setTitle(tr("&Sessions"));
     msession->setOnAllDisabledBehavior(ActionContainer::Show);
     mfile->addMenu(msession, Core::Constants::G_FILE_OPEN);
     dd->m_sessionMenu = msession->menu();
@@ -3298,7 +3298,9 @@ void ProjectExplorerPluginPrivate::updateSessionMenu()
     QActionGroup *ag = new QActionGroup(m_sessionMenu);
     connect(ag, &QActionGroup::triggered, this, &ProjectExplorerPluginPrivate::setSession);
     const QString activeSession = SessionManager::activeSession();
-    foreach (const QString &session, SessionManager::sessions()) {
+    QStringList ss(SessionManager::sessions());
+    qSort(ss.begin(), ss.end());
+    foreach (QString const & session, ss) {
         QAction *act = ag->addAction(session);
         act->setData(session);
         act->setCheckable(true);
diff --git a/src/plugins/projectexplorer/sessiondialog.cpp b/src/plugins/projectexplorer/sessiondialog.cpp
index 8e05f76..005850c 100644
--- a/src/plugins/projectexplorer/sessiondialog.cpp
+++ b/src/plugins/projectexplorer/sessiondialog.cpp
@@ -158,6 +158,7 @@ bool SessionDialog::autoLoadSession() const
 void SessionDialog::addItems(bool setDefaultSession)
 {
     QStringList sessions = SessionManager::sessions();
+    qSort(sessions.begin(), sessions.end());
     foreach (const QString &session, sessions) {
         m_ui.sessionList->addItem(session);
         if (setDefaultSession && session == SessionManager::activeSession())
@@ -186,6 +187,7 @@ void SessionDialog::addSessionToUi(const QString &name, bool switchTo)
 {
     m_ui.sessionList->clear();
     QStringList sessions = SessionManager::sessions();
+    qSort(sessions.begin(), sessions.end());
     m_ui.sessionList->addItems(sessions);
     m_ui.sessionList->setCurrentRow(sessions.indexOf(name));
     markItems();

```

Best regards,
J