### PR TITLE
The purpose of the development is to have a kind of 'class' completion.

### DIFF
--- a/src/plugins/cppeditor/cppeditordocument.cpp
+++ b/src/plugins/cppeditor/cppeditordocument.cpp
@@ -127,6 +127,12 @@ TextEditor::CompletionAssistProvider *CppEditorDocument::completionAssistProvide
     return m_completionAssistProvider;
 }
 
+TextEditor::CompletionAssistProvider *CppEditorDocument::classCompletionAssistProvider() const
+{
+   return &*m_cppClassCompletionAssistProvider;
+}
+
+
 TextEditor::QuickFixAssistProvider *CppEditorDocument::quickFixAssistProvider() const
 {
     return CppEditorPlugin::instance()->quickFixProvider();

--- a/src/plugins/cppeditor/cppeditordocument.h
+++ b/src/plugins/cppeditor/cppeditordocument.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <cpptools/baseeditordocumentprocessor.h>
+#include <cpptools/cppclasscompletionassist.h>
 #include <cpptools/cppcompletionassistprovider.h>
 #include <cpptools/cppmodelmanager.h>
 #include <cpptools/cppsemanticinfo.h>
@@ -50,6 +51,7 @@ public:
 
     bool isObjCEnabled() const;
     TextEditor::CompletionAssistProvider *completionAssistProvider() const override;
+    TextEditor::CompletionAssistProvider *classCompletionAssistProvider() const override;
     TextEditor::QuickFixAssistProvider *quickFixAssistProvider() const override;
 
     void recalculateSemanticInfoDetached();
@@ -109,6 +111,7 @@ private:
     QScopedPointer<CppTools::BaseEditorDocumentProcessor> m_processor;
 
     CppTools::CppCompletionAssistProvider *m_completionAssistProvider;
+    QScopedPointer<CppTools::CppClassCompletionAssistProvider> m_cppClassCompletionAssistProvider{new CppTools::CppClassCompletionAssistProvider};
 
     // (Un)Registration in CppModelManager
     QScopedPointer<CppTools::CppEditorDocumentHandle> m_editorDocumentHandle;

--- a/src/plugins/cpptools/cppclasscompletionassist.cpp
+++ b/src/plugins/cpptools/cppclasscompletionassist.cpp
@@ -1,0 +1,265 @@
+
+#include "cppclasscompletionassist.h"
+#include <cpptools/cppcompletionassist.h>
+#include <cpptools/cpplocatorfilter.h>
+#include <cpptools/cpprefactoringhelper.h>
+#include <extensionsystem/pluginmanager.h>
+#include <texteditor/codeassist/assistproposalitem.h>
+#include <texteditor/codeassist/genericproposal.h>
+#include <utils/qtcassert.h>
+
+namespace CppTools {
+
+TextEditor::IAssistProcessor*CppClassCompletionAssistProvider::createProcessor() const
+{
+   return new CppClassCompletionAssistProcessor;
+}
+
+TextEditor::AssistInterface*CppClassCompletionAssistProvider::createAssistInterface(const QString& filePath, const TextEditor::TextEditorWidget* textEditorWidget,
+                                                                                    const CPlusPlus::LanguageFeatures& languageFeatures,
+                                                                                    int position, TextEditor::AssistReason reason) const
+{
+   QTC_ASSERT(textEditorWidget, return 0);
+
+   return new CppTools::Internal::CppCompletionAssistInterface(filePath,
+                                                               textEditorWidget,
+                                                               BuiltinEditorDocumentParser::get(filePath),
+                                                               languageFeatures,
+                                                               position,
+                                                               reason,
+                                                               CppModelManager::instance()->workingCopy());
+}
+
+TextEditor::IAssistProposal*CppClassCompletionAssistProcessor::perform(const TextEditor::AssistInterface* interface)
+{
+   classCompletion(interface->fileName(), m_positionForProposal);
+   return createContentProposal();
+}
+
+
+bool CppClassCompletionAssistProcessor::classCompletion(const QString &filename, int& positionOfProposals)
+{
+   bool result = true;
+   CPlusPlus::Snapshot snapshot = CppTools::CppModelManager::instance()->snapshot();
+   CppTools::CppRefactoringChanges cppRefactoringChanges(snapshot);
+   CppTools::CppRefactoringFilePtr currentFile = cppRefactoringChanges.file(filename);
+
+   if(currentFile->cppDocument().data()==NULL || !currentFile->cppDocument())
+      return result;
+
+   int requestPosition = currentFile->cursor().position();
+
+   QStringList foundProposals;
+   QString regexpString;
+   executeClassCompletion(currentFile, requestPosition, positionOfProposals, foundProposals, regexpString);
+   regexpString = QLatin1String("(^|:)") + regexpString + QLatin1String("$");
+   m_qRegExp = QSharedPointer<QRegExp>(new QRegExp(regexpString));
+
+   int order = 0;
+   foreach(const QString& proposals, foundProposals)
+   {
+      if(!proposals.isEmpty()) {
+         addCompletionItemWithRegexp(proposals, QIcon(), order, m_qRegExp);
+         ++order;
+      }
+   }
+
+   return result;
+}
+
+TextEditor::IAssistProposal*CppClassCompletionAssistProcessor::createContentProposal()
+{
+   TextEditor::GenericProposalModel *model = new TextEditor::GenericProposalModel;
+   model->loadContent(m_completions);
+   return new TextEditor::GenericProposal(m_positionForProposal, model);
+
+}
+
+void CppClassCompletionAssistProcessor::createRegexpForUpperCase(const QString& expression, QString& regexp) const
+{
+   bool first = true;
+   bool ignoreNext = false;
+   for(QString::const_iterator it1 = expression.cbegin(), itEnd1 = expression.cend();it1!=itEnd1;++it1)
+   {
+       const QChar& chr = *it1;
+
+       if(chr.isUpper() && !first &&!ignoreNext) {
+          regexp += QLatin1String("[a-z0-9_]*");
+          ignoreNext = false;
+       } else if(chr == QLatin1Char('*')) {
+          regexp += QLatin1String("[A-Za-z0-9_]");
+          ignoreNext = true;
+       } else if(ignoreNext)
+          ignoreNext = false;
+
+      regexp += chr;
+       if(first)
+          first = false;
+   }
+   regexp += QLatin1String("[A-Za-z0-9_]*");
+}
+
+void CppClassCompletionAssistProcessor::getCurrentSymbolForClassCompletion(CppTools::CppRefactoringFilePtr currentFile, int requestPosition, QString& symbol, int& symbolPosition)
+{
+   symbol = CppRefactoringHelper::getSymbolAtPosition(currentFile, requestPosition, CppRefactoringHelper::isCharOfClassCompletionSymbolBackward,
+                                          CppRefactoringHelper::isCharOfClassCompletionSymbolForward, symbolPosition);
+}
+
+
+void CppClassCompletionAssistProcessor::executeClassCompletion(CppTools::CppRefactoringFilePtr currentFile,
+                                                             int requestPosition, int& proposalPosition, QStringList& proposals, QString& regExp)
+{
+   unsigned int line, column;
+   currentFile->lineAndColumn(requestPosition, &line, &column);
+
+   CPlusPlus::Scope *currentScope = currentFile->cppDocument()->scopeAt(line, column);
+
+   QStringList vCallerNamespace;
+   QStringList vCallerClassAsNamespaceElements;
+   CppRefactoringHelper::getNamespaceAndClassElementsFromScope(currentScope, vCallerNamespace, vCallerClassAsNamespaceElements);
+
+   QMap<QString, QString> namespaceAliases;
+   QMap<QString, int> namespaceAliasesLine;
+
+   if(!CppRefactoringHelper::isHeaderFile(currentFile->fileName()))
+      CppRefactoringHelper::getNamespaceAliasesInFile(currentFile, namespaceAliases, namespaceAliasesLine);
+
+    QString cursorSymbol;
+    getCurrentSymbolForClassCompletion(currentFile, requestPosition, cursorSymbol, proposalPosition);
+    if(cursorSymbol.size()==0)
+        return;
+
+    CPlusPlus::Scope *initScope = currentFile->cppDocument()->scopeAt(line,column);
+    if(!initScope)
+        return;
+
+    // complete the regexp
+    QString regexpPattern;
+    createRegexpForUpperCase(cursorSymbol, regexpPattern);
+    regExp = regexpPattern;
+    regexpPattern.prepend(QLatin1Char('^'));
+    QRegExp qRegExp(regexpPattern);
+
+    QMap<int, QSet<QString> > proposalsMap;
+    CppTools::Internal::CppLocatorFilter* cppLocatorFilter = ExtensionSystem::PluginManager::getObject<CppTools::Internal::CppLocatorFilter>();
+    QFutureInterface<Core::LocatorFilterEntry> dummyInterface;
+    QList<Core::LocatorFilterEntry> matches = cppLocatorFilter->matchesRegexp(dummyInterface, qRegExp);
+
+    foreach (const Core::LocatorFilterEntry &entry, matches)
+    {
+        IndexItem::Ptr info = entry.internalData.value<IndexItem::Ptr>();
+        // if the symbol is in an header file or in the current file
+        if(CppRefactoringHelper::isHeaderFile(info->fileName())||info->fileName()==currentFile->fileName())
+        {
+            QString fullClassName = info->scopedSymbolName();
+            QStringList vNamespaceElements;
+            QStringList vClassAsNamespaceElements;
+            QString className;
+
+            CppRefactoringHelper::getNamespaceAndClass(fullClassName, vNamespaceElements, vClassAsNamespaceElements, className);
+
+            QString proposition;
+            int callerNamespaceDistance;
+            transformQualifiedClassIntoProposition(className, vNamespaceElements, vClassAsNamespaceElements, vCallerNamespace,
+                                                   vCallerClassAsNamespaceElements, namespaceAliases, proposition, callerNamespaceDistance);
+            proposalsMap[callerNamespaceDistance].insert(proposition);
+        }
+    }
+
+    orderProposals(cursorSymbol, proposalsMap, proposals);
+
+    if(!proposalsMap.empty())
+    {
+       TextEditor::TextEditorWidget* textEditorWidget = currentFile->editor();
+       if(textEditorWidget)
+       {
+          int endOfCursorSymbolPosition = proposalPosition + cursorSymbol.size();
+          QTextCursor qTextCursor = textEditorWidget->textCursor();
+          qTextCursor.setPosition(endOfCursorSymbolPosition);
+          textEditorWidget->setTextCursor(qTextCursor);
+       }
+    }
+}
+
+
+void CppClassCompletionAssistProcessor::transformQualifiedClassIntoProposition(const QString& className, const QStringList& vNamespaceElements, const QStringList& vClassAsNamespaceElements,
+                                                                               const QStringList& vCallerNamespace, const QStringList& vCallerClassAsNamespaceElements,
+                                                                               const QMap<QString, QString>& namespaceAliases,
+                                                                               QString& proposition, int& callerNamespaceDistance)
+{
+   QStringList vDiffNamespace;
+   CppRefactoringHelper::reduceNamespace(vNamespaceElements, vCallerNamespace, vDiffNamespace);
+   callerNamespaceDistance = vDiffNamespace.size();
+
+   proposition = QLatin1String("");
+   if(callerNamespaceDistance!=0) {
+      QString propositionNamespace = CppRefactoringHelper::buildFromNamespaceElements(vNamespaceElements);
+      QMap<QString, QString>::const_iterator itAlias = namespaceAliases.find(propositionNamespace);
+      if(itAlias!=namespaceAliases.end()){
+         proposition = itAlias.value();
+         callerNamespaceDistance = 1;
+      } else
+         proposition = propositionNamespace;
+      proposition += QLatin1String("::");
+   }
+
+
+   QStringList vDiffClassAsNamespace;
+   if(callerNamespaceDistance==0){
+      CppRefactoringHelper::reduceNamespace(vClassAsNamespaceElements, vCallerClassAsNamespaceElements, vDiffClassAsNamespace);
+   } else
+      vDiffClassAsNamespace = vClassAsNamespaceElements;
+
+   if(vDiffClassAsNamespace.size()!=0){
+      callerNamespaceDistance += vDiffClassAsNamespace.size();
+      proposition += CppRefactoringHelper::buildFromNamespaceElements(vDiffClassAsNamespace) + QLatin1String("::");
+   }
+
+   proposition += className;
+}
+
+void CppClassCompletionAssistProcessor::orderProposals(const QString& cursorSymbol, const QMap<int, QSet<QString> >& proposalsMap, QStringList& proposals)
+{
+   QStringList exactMatches;
+   QStringList otherMatches;
+
+   for(QMap<int, QSet<QString> >::const_iterator it1=proposalsMap.begin(), itEnd1=proposalsMap.end();it1!=itEnd1;++it1)
+   {
+      QStringList localExactMatches;
+      QStringList localOtherMatches;
+      const QSet<QString>& proposalsSet = it1.value();
+
+      foreach(const QString& proposal, proposalsSet){
+         if(proposal.endsWith(cursorSymbol))
+            localExactMatches.append(proposal);
+         else
+            localOtherMatches.append(proposal);
+      }
+
+      localExactMatches.sort();
+      localOtherMatches.sort();
+
+      exactMatches.append(localExactMatches);
+      otherMatches.append(localOtherMatches);
+   }
+
+   foreach(const QString& exactMatch, exactMatches){
+      proposals.push_back(exactMatch);
+   }
+
+   foreach(const QString& otherMatch, otherMatches){
+      proposals.push_back(otherMatch);
+   }
+}
+
+void CppClassCompletionAssistProcessor::addCompletionItemWithRegexp(const QString& text, const QIcon& icon, int order, const QSharedPointer<QRegExp>& qRegExp)
+{
+   TextEditor::AssistProposalItem *item = new TextEditor::AssistProposalItem;
+   item->setText(text);
+   item->setIcon(icon);
+   item->setOrder(order);
+   item->setCustomizeRegexp(qRegExp);
+   m_completions.append(item);
+}
+
+}

--- a/src/plugins/cpptools/cppclasscompletionassist.h
+++ b/src/plugins/cpptools/cppclasscompletionassist.h
@@ -1,0 +1,95 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of Qt Creator.
+**
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3 as published by the Free Software
+** Foundation with exceptions as appearing in the file LICENSE.GPL3-EXCEPT
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-3.0.html.
+**
+****************************************************************************/
+
+#pragma once
+
+#include "builtineditordocumentparser.h"
+#include "cppcompletionassistprocessor.h"
+#include "cppcompletionassistprovider.h"
+#include "cppmodelmanager.h"
+#include <cpptools/cpprefactoringchanges.h>
+#include "cppworkingcopy.h"
+
+#include <cplusplus/Icons.h>
+#include <cplusplus/Symbol.h>
+#include <cplusplus/TypeOfExpression.h>
+
+#include <texteditor/texteditor.h>
+#include <texteditor/codeassist/genericproposalmodel.h>
+#include <texteditor/codeassist/assistinterface.h>
+#include <texteditor/codeassist/iassistprocessor.h>
+#include <texteditor/snippets/snippetassistcollector.h>
+
+
+#include <QStringList>
+#include <QVariant>
+
+namespace CPlusPlus {
+class LookupItem;
+class ClassOrNamespace;
+class Function;
+class LookupContext;
+} // namespace CPlusPlus
+
+namespace CppTools {
+
+class CppCompletionAssistInterface;
+class CppAssistProposalModel;
+
+class CPPTOOLS_EXPORT CppClassCompletionAssistProvider : public CppCompletionAssistProvider
+{
+    Q_OBJECT
+
+public:
+    TextEditor::IAssistProcessor *createProcessor() const override;
+
+    TextEditor::AssistInterface *createAssistInterface(
+            const QString &filePath,
+            const TextEditor::TextEditorWidget *textEditorWidget,
+            const CPlusPlus::LanguageFeatures &languageFeatures,
+            int position,
+            TextEditor::AssistReason reason) const override;
+};
+
+class CppClassCompletionAssistProcessor : public CppCompletionAssistProcessor
+{
+public:
+   TextEditor::IAssistProposal *perform(const TextEditor::AssistInterface *interface) override;
+private:
+   bool classCompletion(const QString& filename, int& positionOfProposals);
+   TextEditor::IAssistProposal *createContentProposal();
+   void addCompletionItemWithRegexp(const QString& text, const QIcon& icon, int order, const QSharedPointer<QRegExp>& qRegExp);
+   void executeClassCompletion(CppTools::CppRefactoringFilePtr currentFile, int requestPosition, int& proposalPosition, QStringList& proposals, QString& regExp);
+   void getCurrentSymbolForClassCompletion(CppTools::CppRefactoringFilePtr currentFile, int requestPosition, QString& symbol, int& symbolPosition);
+   void createRegexpForUpperCase(const QString& expression, QString& regexp) const;
+   void orderProposals(const QString& cursorSymbol, const QMap<int, QSet<QString> >& proposalsMap, QStringList& proposals);
+   void transformQualifiedClassIntoProposition(const QString& className, const QStringList& vNamespaceElements, const QStringList& vClassAsNamespaceElements, const QStringList& vCallerClassNamespace, const QStringList& vCallerClassAsNamespaceElements, const QMap<QString, QString>& namespaceAliases, QString& proposition, int& callerNamespaceDistance);
+   QSharedPointer<QRegExp> m_qRegExp;
+};
+
+
+
+} // CppTools
+

--- a/src/plugins/cpptools/cppindexingsupport.h
+++ b/src/plugins/cpptools/cppindexingsupport.h
@@ -47,7 +47,8 @@ public:
         Classes      = 0x1,
         Functions    = 0x2,
         Enums        = 0x4,
-        Declarations = 0x8
+        Declarations = 0x8,
+        TypedefDeclarations = 0x10
     };
 
     Q_DECLARE_FLAGS(SymbolTypes, SymbolType)

--- a/src/plugins/cpptools/cpplocatordata.cpp
+++ b/src/plugins/cpptools/cpplocatordata.cpp
@@ -38,7 +38,8 @@ CppLocatorData::CppLocatorData()
 {
     m_search.setSymbolsToSearchFor(SymbolSearcher::Enums |
                                    SymbolSearcher::Classes |
-                                   SymbolSearcher::Functions);
+                                   SymbolSearcher::Functions |
+                                   SymbolSearcher::TypedefDeclarations);
     m_pendingDocuments.reserve(MaxPendingDocuments);
 }
 

--- a/src/plugins/cpptools/cpplocatorfilter.h
+++ b/src/plugins/cpptools/cpplocatorfilter.h
@@ -43,6 +43,7 @@ public:
 
     QList<Core::LocatorFilterEntry> matchesFor(QFutureInterface<Core::LocatorFilterEntry> &future,
                                                const QString &entry);
+    QList<Core::LocatorFilterEntry> matchesRegexp(QFutureInterface<Core::LocatorFilterEntry> &future, const QRegExp &entry);
     void accept(Core::LocatorFilterEntry selection) const;
     void refresh(QFutureInterface<void> &future);
 

--- a/src/plugins/cpptools/cpprefactoringhelper.cpp
+++ b/src/plugins/cpptools/cpprefactoringhelper.cpp
@@ -1,0 +1,276 @@
+#include "cplusplus/Scope.h"
+#include "cplusplus/Symbol.h"
+#include "cpptools/cpprefactoringhelper.h"
+
+QString CppRefactoringHelper::buildFromNamespaceElements(const QStringList& namespaceElements)
+{
+   return namespaceElements.join(QLatin1String("::"));
+}
+
+bool CppRefactoringHelper::isCharOfClassCompletionSymbolForward(const QChar& qChar)
+{
+   return (qChar.isLetterOrNumber() || qChar==QLatin1Char('_') || qChar==QLatin1Char('^') || qChar==QLatin1Char('*'));
+}
+
+bool CppRefactoringHelper::isCharOfClassCompletionSymbolBackward(const QChar& qChar)
+{
+   return (qChar.isLetterOrNumber() || qChar==QLatin1Char('_') || qChar==QLatin1Char('^') || qChar==QLatin1Char('*') || qChar==QLatin1Char(':'));
+}
+
+Utils::ChangeSet::Range CppRefactoringHelper::getSymbolRange(CppTools::CppRefactoringFilePtr& file, int initialPosition,
+                                                 SymbolFilter* symbolFilterBackward, SymbolFilter* symbolFilterForward)
+{
+   int currentPosition = initialPosition;
+   QChar qChar;
+   qChar = file->charAt(currentPosition);
+
+   // in case we are at the last character
+   if(!symbolFilterBackward(qChar)){
+       --currentPosition;
+       if(currentPosition>0)
+          qChar = file->charAt(currentPosition);
+   }
+   int firstValidPosition = currentPosition;
+
+   while(currentPosition>0 && symbolFilterBackward(qChar)){
+      --currentPosition;
+      if(currentPosition>0)
+         qChar = file->charAt(currentPosition);
+   }
+   ++currentPosition;
+   int startPosition = currentPosition;
+
+   currentPosition = firstValidPosition;
+   if(currentPosition>0)
+      qChar = file->charAt(currentPosition);
+
+   while(symbolFilterForward(qChar))
+   {
+      ++currentPosition;
+      qChar = file->charAt(currentPosition);
+   }
+   int endPosition = currentPosition;
+
+   return Utils::ChangeSet::Range(startPosition, endPosition);
+}
+
+QString CppRefactoringHelper::getSymbolAtPosition(CppTools::CppRefactoringFilePtr &file, int initialPosition, SymbolFilter* symbolFilterBackward,
+                                      SymbolFilter* symbolFilterForward, int& symbolPosition)
+{
+   Utils::ChangeSet::Range symbolRange = getSymbolRange(file, initialPosition, symbolFilterBackward, symbolFilterForward);
+   symbolPosition = symbolRange.start;
+   return static_cast<TextEditor::RefactoringFile*>(file.data())->textOf(symbolRange);
+}
+
+void CppRefactoringHelper::getNamespaceElementsFromClass(CPlusPlus::Class* clazz, QStringList& vNamespaceElements)
+{
+   CPlusPlus::Namespace* enclosingNamespace = clazz->enclosingNamespace();
+
+   while(enclosingNamespace) {
+      const CPlusPlus::Identifier *identifier = enclosingNamespace->identifier();
+
+      if(identifier) {
+         const char * scopeName = identifier->chars();
+         if(scopeName && scopeName[0]!=0 && scopeName[0]!='<') {
+            vNamespaceElements.prepend(QLatin1String(scopeName));
+         }
+      }
+
+      enclosingNamespace = enclosingNamespace->enclosingNamespace();
+   }
+}
+
+
+void CppRefactoringHelper::getNamespaceAndClassElementsFromSymbol(CPlusPlus::Symbol* symbol, QStringList& vNamespaceElements,
+                                                                  QStringList& vClassElements, QString& otherElements)
+{
+   const CPlusPlus::Identifier *symbolIdentifier = symbol->identifier();
+   if(symbolIdentifier)
+      otherElements = QString::fromLatin1(symbolIdentifier->chars(), static_cast<int>(symbolIdentifier->size()));
+
+   bool ignoreNextElement = false;
+   if(symbol->isClass()||symbol->isNamespace())
+      ignoreNextElement = true;
+
+   CPlusPlus::Symbol* enclosingSymbol = symbol;
+
+   enum Item {
+      ITEM_UNDEFINED,
+      ITEM_CLASS,
+      ITEM_NAMESPACE
+   };
+
+   QList<QPair<Item, QString> > namespaceItems;
+   // we go up on the enclosingSymbols, and we find the namespace and class
+   while(enclosingSymbol)
+   {
+      const CPlusPlus::Identifier *identifier = NULL;
+      Item item = ITEM_UNDEFINED;
+
+      // we find the
+      do
+      {
+         item = ITEM_UNDEFINED;
+         if(CPlusPlus::Class* enclosingClass = enclosingSymbol->asClass())
+         {
+            identifier = enclosingClass->identifier();
+            item = ITEM_CLASS;
+         } else if(CPlusPlus::Namespace* enclosingNamespace = enclosingSymbol->asNamespace())
+         {
+            identifier = enclosingNamespace->identifier();
+            item = ITEM_NAMESPACE;
+         }
+
+         enclosingSymbol = enclosingSymbol->enclosingScope();
+      } while(enclosingSymbol&&!identifier);
+
+      if(ignoreNextElement)
+      {
+         ignoreNextElement = false;
+      } else if(identifier) {
+         const char * scopeName = identifier->chars();
+         if(scopeName && scopeName[0]!=0 && scopeName[0]!='<') {
+            namespaceItems.prepend(qMakePair(item, QLatin1String(scopeName)));
+         }
+      }
+   }
+
+   bool fillNamespace = true;
+   for(QList<QPair<Item, QString> >::iterator it1=namespaceItems.begin(), itEnd1=namespaceItems.end(); it1!=itEnd1; ++it1){
+      Item item = it1->first;
+      if(!fillNamespace || item==ITEM_CLASS){
+         fillNamespace = false;
+         vClassElements.append(it1->second);
+      } else if (item==ITEM_NAMESPACE){
+         vNamespaceElements.append(it1->second);
+      }
+   }
+}
+
+void CppRefactoringHelper::getNamespaceAndClassElementsFromScope(CPlusPlus::Scope *scope, QStringList& vNamespaceElements,
+                                                     QStringList& vClassAsNamespaceElements)
+{
+   QString otherElements;
+   getNamespaceAndClassElementsFromSymbol(scope, vNamespaceElements, vClassAsNamespaceElements, otherElements);
+
+}
+
+
+void CppRefactoringHelper::getNamespaceAliasesInFile(CppTools::CppRefactoringFilePtr& cppFile, QMap<QString, QString>& namespaceAliases, QMap<QString, int>& namespaceAliasesLine)
+{
+   CPlusPlus::Namespace* globalNamespace = cppFile->cppDocument()->globalNamespace();
+   for(CPlusPlus::Scope::iterator it1=globalNamespace->memberBegin(), itEnd1=globalNamespace->memberEnd(); it1!=itEnd1; ++it1) {
+      CPlusPlus::Symbol* symbol = *it1;
+      if(CPlusPlus::NamespaceAlias *namespaceAlias = symbol->asNamespaceAlias()){
+         // normally test not useful
+         if(cppFile->fileName()==QLatin1String(symbol->fileName())){
+            const char *aliasChars = 0;
+            if(const CPlusPlus::Identifier *identifierAlias = namespaceAlias->identifier()){
+               aliasChars = identifierAlias->chars();
+            } else
+               continue;
+
+            QString aliasedNamespace;
+            const CPlusPlus::QualifiedNameId* qualifiedName = namespaceAlias->namespaceName()->asQualifiedNameId();
+            while(qualifiedName){
+
+               const CPlusPlus::Identifier *identifier = qualifiedName->identifier();
+               if(identifier){
+                  if(!aliasedNamespace.isEmpty())
+                     aliasedNamespace.prepend(QLatin1String("::"));
+                  aliasedNamespace.prepend(QLatin1String(identifier->chars()));
+               }
+
+               const CPlusPlus::Name* base = qualifiedName->base();
+               if(base) {
+                  qualifiedName = base->asQualifiedNameId();
+                  if(qualifiedName == 0) {
+                     // last element
+                     const CPlusPlus::Identifier *identifier = base->identifier();
+                     if(identifier){
+                        if(!aliasedNamespace.isEmpty())
+                           aliasedNamespace.prepend(QLatin1String("::"));
+                        aliasedNamespace.prepend(QLatin1String(identifier->chars()));
+                     }
+                  }
+               } else
+                  qualifiedName = 0;
+
+            }
+
+            if(aliasChars && aliasedNamespace.size()>0){
+               namespaceAliases.insert(aliasedNamespace, QLatin1String(aliasChars));
+               namespaceAliasesLine.insert(aliasedNamespace, static_cast<int>(symbol->line()));
+            }
+         }
+      }
+   }
+}
+
+bool CppRefactoringHelper::isHeaderFile(const QString& filename)
+{
+    return (!filename.endsWith(QLatin1String(".cpp"))&&!filename.endsWith(QLatin1String(".c")));
+
+}
+
+void CppRefactoringHelper::getNamespaceAndClass(const QString& fullySpecifiedClassName, QStringList& vNamespaceElements, QStringList& vClassAsNamespaceElements, QString& className)
+{
+    enum Status{
+        NORMAL_CHR,
+        COLON_FOUND
+    };
+
+    bool bClassNamespace = false;
+    QString currentSymbol;
+    Status status = NORMAL_CHR;
+    for(QString::const_iterator it1 = fullySpecifiedClassName.cbegin(), itEnd1 = fullySpecifiedClassName.cend();it1!=itEnd1;++it1)
+    {
+       const QChar& chr = *it1;
+       if(status==COLON_FOUND) {
+          if(chr==QLatin1Char(':')){
+             if(currentSymbol.size()>0) {
+                if(currentSymbol[0].isUpper())
+                   bClassNamespace = true;
+                if(bClassNamespace)
+                   vClassAsNamespaceElements.append(currentSymbol);
+                else
+                   vNamespaceElements.append(currentSymbol);
+             }
+             currentSymbol.clear();
+          } else {
+             currentSymbol.append(chr);
+          }
+          status = NORMAL_CHR;
+       }else if (status==NORMAL_CHR) {
+          if(chr==QLatin1Char(':'))
+             status = COLON_FOUND;
+          else
+             currentSymbol.append(chr);
+       }
+    }
+
+    className = currentSymbol;
+}
+
+
+void CppRefactoringHelper::reduceNamespace(const QStringList& vNamespaceUsed, const QStringList& vNamespaceUsing, QStringList& vDiffNamespace)
+{
+
+   QStringList::const_iterator itUsed = vNamespaceUsed.cbegin();
+   QStringList::const_iterator itUsedEnd = vNamespaceUsed.cend();
+   QStringList::const_iterator itUsing = vNamespaceUsing.cbegin();
+   QStringList::const_iterator itUsingEnd = vNamespaceUsing.cend();
+
+   while(itUsed!=itUsedEnd && itUsing!=itUsingEnd) {
+       if(*itUsed != *itUsing)
+          break;
+       ++itUsed;
+       ++itUsing;
+   }
+
+   while (itUsed!=itUsedEnd) {
+      vDiffNamespace.append(*itUsed);
+      ++itUsed;
+   }
+
+}

--- a/src/plugins/cpptools/cpprefactoringhelper.h
+++ b/src/plugins/cpptools/cpprefactoringhelper.h
@@ -1,0 +1,38 @@
+#ifndef CPPREFACTPRINGHELPER_H
+#define CPPREFACTPRINGHELPER_H
+
+#include "cplusplus/FindUsages.h"
+#include "cplusplus/Symbol.h"
+#include <cpptools/cppmodelmanager.h>
+#include "cpptools/cpprefactoringchanges.h"
+#include "cppworkingcopy.h"
+#include <projectexplorer/projectnodes.h>
+#include "qstringlist.h"
+#include "utils/changeset.h"
+#include "cpptools_global.h"
+
+
+
+class CPPTOOLS_EXPORT CppRefactoringHelper
+{
+public:
+    static QString buildFromNamespaceElements(const QStringList &namespaceElements);
+    static bool isHeaderFile(const QString& filename);
+    typedef bool (SymbolFilter)(const QChar &);
+    static bool isCharOfClassCompletionSymbolForward(const QChar& qChar);
+    static bool isCharOfClassCompletionSymbolBackward(const QChar& qChar);
+    static Utils::ChangeSet::Range getSymbolRange(CppTools::CppRefactoringFilePtr &file, int initialPosition,
+                                                  SymbolFilter* symbolFilterBackward, SymbolFilter* symbolFilterForward);
+    static QString getSymbolAtPosition(CppTools::CppRefactoringFilePtr &file, int initialPosition, SymbolFilter* symbolFilterBackward,
+                                       SymbolFilter* symbolFilterForward, int& symbolPosition);
+
+    static void getNamespaceAndClassElementsFromSymbol(CPlusPlus::Symbol* symbol, QStringList& vNamespaceElements, QStringList& vClassElements, QString& otherElements);
+    static void getNamespaceAndClassElementsFromScope(CPlusPlus::Scope* scope, QStringList& vNamespaceElements,
+                                                      QStringList& vClassAsNamespaceElements);
+    static void getNamespaceElementsFromClass(CPlusPlus::Class* clazz, QStringList& vNamespaceElements);
+    static void reduceNamespace(const QStringList& vNamespaceUsed, const QStringList& vNamespaceUsing, QStringList& vDiffNamespace);
+    static void getNamespaceAliasesInFile(CppTools::CppRefactoringFilePtr &cppFile, QMap<QString, QString> &namespaceAliases, QMap<QString, int> &namespaceAliasesLine);
+    static void getNamespaceAndClass(const QString& fullySpecifiedClassName, QStringList& vNamespaceElements, QStringList& vClassAsNamespaceElements, QString& className);
+};
+
+#endif

--- a/src/plugins/cpptools/cpptools.pro
+++ b/src/plugins/cpptools/cpptools.pro
@@ -77,7 +77,10 @@ HEADERS += \
     projectinfo.h \
     projectpartbuilder.h \
     compileroptionsbuilder.h \
-    refactoringengineinterface.h
+    refactoringengineinterface.h \
+    cpprefactoringhelper.h \
+    cppclasscompletionassist.h
+
 SOURCES += \
     abstracteditorsupport.cpp \
     baseeditordocumentparser.cpp \
@@ -148,7 +151,9 @@ SOURCES += \
     projectpart.cpp \
     projectinfo.cpp \
     projectpartbuilder.cpp \
-    compileroptionsbuilder.cpp
+    compileroptionsbuilder.cpp \
+    cpprefactoringhelper.cpp \
+    cppclasscompletionassist.cpp
 
 FORMS += \
     clangdiagnosticconfigswidget.ui \

--- a/src/plugins/cpptools/indexitem.h
+++ b/src/plugins/cpptools/indexitem.h
@@ -47,8 +47,9 @@ public:
         Class       = 1 << 1,
         Function    = 1 << 2,
         Declaration = 1 << 3,
+        TypedefDeclaration = 1 << 4,
 
-        All = Enum | Class | Function | Declaration
+        All = Enum | Class | Function | Declaration | TypedefDeclaration
     };
 
 public:

--- a/src/plugins/cpptools/searchsymbols.cpp
+++ b/src/plugins/cpptools/searchsymbols.cpp
@@ -120,31 +120,46 @@ bool SearchSymbols::visit(Namespace *symbol)
 
 bool SearchSymbols::visit(Declaration *symbol)
 {
-    if (!(symbolsToSearchFor & SymbolSearcher::Declarations)) {
-        // if we're searching for functions, still allow signal declarations to show up.
-        if (symbolsToSearchFor & SymbolSearcher::Functions) {
+
+   // not really beautiful, case too complex
+   if(symbol->isTypedef() && (symbolsToSearchFor & SymbolSearcher::TypedefDeclarations) && !(symbolsToSearchFor & SymbolSearcher::Declarations))
+   {
+      if (symbol->name())
+      {
+         QString name = overview.prettyName(symbol->name());
+         QString type = overview.prettyType(symbol->type());
+         addChildItem(name, type, _scope, IndexItem::TypedefDeclaration, symbol);
+      }
+
+   }
+   else
+   {
+      if (!(symbolsToSearchFor & SymbolSearcher::Declarations)) {
+         // if we're searching for functions, still allow signal declarations to show up.
+         if (symbolsToSearchFor & SymbolSearcher::Functions) {
             Function *funTy = symbol->type()->asFunctionType();
             if (!funTy) {
-                if (!symbol->type()->asObjCMethodType())
-                    return false;
+               if (!symbol->type()->asObjCMethodType())
+                  return false;
             } else if (!funTy->isSignal()) {
-                return false;
+               return false;
             }
-        } else {
+         } else {
             return false;
-        }
-    }
+         }
+      }
 
-    if (symbol->name()) {
-        QString name = overview.prettyName(symbol->name());
-        QString type = overview.prettyType(symbol->type());
-        addChildItem(name, type, _scope,
-                     symbol->type()->asFunctionType() ? IndexItem::Function
-                                                      : IndexItem::Declaration,
-                     symbol);
-    }
+      if (symbol->name()) {
+         QString name = overview.prettyName(symbol->name());
+         QString type = overview.prettyType(symbol->type());
+         addChildItem(name, type, _scope,
+                      symbol->type()->asFunctionType() ? IndexItem::Function
+                                                       : IndexItem::Declaration,
+                      symbol);
+      }
+   }
 
-    return false;
+   return false;
 }
 
 bool SearchSymbols::visit(Class *symbol)

--- a/src/plugins/texteditor/codeassist/assistenums.h
+++ b/src/plugins/texteditor/codeassist/assistenums.h
@@ -31,7 +31,8 @@ enum AssistKind
 {
     Completion,
     QuickFix,
-    FollowSymbol
+    FollowSymbol,
+    ClassCompletion
 };
 
 enum AssistReason

--- a/src/plugins/texteditor/codeassist/assistproposaliteminterface.h
+++ b/src/plugins/texteditor/codeassist/assistproposaliteminterface.h
@@ -35,6 +35,7 @@ class QString;
 class QVariant;
 QT_END_NAMESPACE
 
+#include <QSharedPointer>
 #include <QString>
 
 namespace TextEditor {
@@ -62,8 +63,13 @@ public:
     int order() const { return m_order; }
     void setOrder(int order) { m_order = order; }
 
+    const QSharedPointer<QRegExp>& customizeRegexp() const { return m_customizeRegexp; }
+    void setCustomizeRegexp(const QSharedPointer<QRegExp>& customizeRegexp) { m_customizeRegexp = customizeRegexp; }
+
 private:
     int m_order = 0;
+    int m_order2 = 0;
+    QSharedPointer<QRegExp> m_customizeRegexp;
 };
 
 } // namespace TextEditor

--- a/src/plugins/texteditor/codeassist/codeassistant.cpp
+++ b/src/plugins/texteditor/codeassist/codeassistant.cpp
@@ -200,6 +200,11 @@ void CodeAssistantPrivate::requestProposal(AssistReason reason,
     if (!provider) {
         if (kind == Completion)
             provider = m_editorWidget->textDocument()->completionAssistProvider();
+        else if (kind == ClassCompletion)
+        {
+           provider = m_editorWidget->textDocument()->classCompletionAssistProvider();
+           kind = Completion;
+        }
         else
             provider = m_editorWidget->textDocument()->quickFixAssistProvider();
 

--- a/src/plugins/texteditor/codeassist/genericproposalmodel.cpp
+++ b/src/plugins/texteditor/codeassist/genericproposalmodel.cpp
@@ -246,9 +246,16 @@ void GenericProposalModel::filter(const QString &prefix)
     QRegExp regExp(keyRegExp);
 
     m_currentItems.clear();
-    foreach (const auto &item, m_originalItems) {
-        if (regExp.indexIn(item->text()) == 0)
-            m_currentItems.append(item);
+    foreach (const auto &item, m_originalItems)
+    {
+       const QSharedPointer<QRegExp> customizeRegexp = item->customizeRegexp();
+       bool keepItem = false;
+       if(customizeRegexp)
+          keepItem = (customizeRegexp->indexIn(item->text()) != -1);
+       else if (regExp.indexIn(item->text()) == 0)
+          keepItem = true;
+       if(keepItem)
+           m_currentItems.append(item);
     }
 }
 

--- a/src/plugins/texteditor/textdocument.cpp
+++ b/src/plugins/texteditor/textdocument.cpp
@@ -372,6 +372,11 @@ CompletionAssistProvider *TextDocument::completionAssistProvider() const
     return d->m_completionAssistProvider;
 }
 
+CompletionAssistProvider*TextDocument::classCompletionAssistProvider() const
+{
+    return 0;
+}
+
 QuickFixAssistProvider *TextDocument::quickFixAssistProvider() const
 {
     return 0;

--- a/src/plugins/texteditor/textdocument.h
+++ b/src/plugins/texteditor/textdocument.h
@@ -131,6 +131,7 @@ public:
 
     void setCompletionAssistProvider(CompletionAssistProvider *provider);
     virtual CompletionAssistProvider *completionAssistProvider() const;
+    virtual CompletionAssistProvider *classCompletionAssistProvider() const;
     virtual QuickFixAssistProvider *quickFixAssistProvider() const;
 
     void setTabSettings(const TextEditor::TabSettings &tabSettings);

--- a/src/plugins/texteditor/texteditorconstants.h
+++ b/src/plugins/texteditor/texteditorconstants.h
@@ -108,6 +108,7 @@ namespace Constants {
 
 const char C_TEXTEDITOR[]          = "Text Editor";
 const char COMPLETE_THIS[]         = "TextEditor.CompleteThis";
+const char CLASS_COMPLETE_THIS[]   = "TextEditor.ClassCompleteThis";
 const char QUICKFIX_THIS[]         = "TextEditor.QuickFix";
 const char CREATE_SCRATCH_BUFFER[] = "TextEditor.CreateScratchBuffer";
 const char VISUALIZE_WHITESPACE[]  = "TextEditor.VisualizeWhitespace";

--- a/src/plugins/texteditor/texteditorplugin.cpp
+++ b/src/plugins/texteditor/texteditorplugin.cpp
@@ -109,6 +109,15 @@ bool TextEditorPlugin::initialize(const QStringList &arguments, QString *errorMe
             editor->editorWidget()->invokeAssist(Completion);
     });
 
+    // Add shortcut for invoking class completion
+    QAction *classCompletionAction = new QAction(tr("Trigger class Completion"), this);
+    Command *classCompletionCommand = ActionManager::registerAction(classCompletionAction, Constants::CLASS_COMPLETE_THIS, context);
+    classCompletionCommand->setDefaultKeySequence(QKeySequence(tr("Ctrl+Shift+Space")));
+    connect(classCompletionAction, &QAction::triggered, []() {
+        if (BaseTextEditor *editor = BaseTextEditor::currentTextEditor())
+            editor->editorWidget()->invokeAssist(ClassCompletion);
+    });
+
     // Add shortcut for invoking quick fix options
     QAction *quickFixAction = new QAction(tr("Trigger Refactoring Action"), this);
     Command *quickFixCommand = ActionManager::registerAction(quickFixAction, Constants::QUICKFIX_THIS, context);


### PR DESCRIPTION
For example, if the class namespace1::namespace2::ThisIsAnExample exists
in the project:

If you type "TIAE" (so the capital letters of the previous class) and
then the shortcut (ctrl + shift + space by default), it proposes to
replace "TIAE" by "namespace1::namespace2::ThisIsAnExample" (or the
alias if there is an alias for namespace1::namespace2)

The head of qtcreator does not compile on windows 7 with vs2013, so I just applied the patch of the modification that is OK on the 4.1 'branch'.