### PR TITLE
[*nix] Makes QtCreator play nicely with HiDPI monitors

### DIFF
--- a/bin/qtcreator.sh
+++ b/bin/qtcreator.sh
@@ -41,4 +41,9 @@ fi
 # Add Qt Creator library path
 LD_LIBRARY_PATH=$libdir:$libdir/qtcreator$qtlibpath${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 export LD_LIBRARY_PATH
+
+# Become DPI-aware
+QT_AUTO_SCREEN_SCALE_FACTOR=1
+export QT_AUTO_SCREEN_SCALE_FACTOR
+
 exec "$bindir/qtcreator" ${1+"$@"}


### PR DESCRIPTION
QtCreator has notoriously been unaware of HiDPI monitors in the past. According to http://doc.qt.io/qt-5/highdpi.html all one needed to do was to set QT_AUTO_SCREEN_SCALE_FACTOR to 1. This seemed like the proper place to make the change.