### PR TITLE
m_reverseDirectionAction->setCheckable was always false

### DIFF
--- a/src/plugins/debugger/debuggerplugin.cpp
+++ b/src/plugins/debugger/debuggerplugin.cpp
@@ -2210,9 +2210,11 @@ void DebuggerPluginPrivate::attachToQmlPort()
 void DebuggerPluginPrivate::enableReverseDebuggingTriggered(const QVariant &value)
 {
     QTC_ASSERT(m_reverseToolButton, return);
-    m_reverseToolButton->setVisible(value.toBool());
+    const bool enabled = value.toBool();
+    m_reverseToolButton->setVisible(enabled);
     m_reverseDirectionAction->setChecked(false);
-    m_reverseDirectionAction->setEnabled(value.toBool());
+    m_reverseDirectionAction->setCheckable(enabled);
+    m_reverseDirectionAction->setEnabled(enabled);
 }
 
 void DebuggerPluginPrivate::runScheduled()


### PR DESCRIPTION
Hi,

I was trying to use the reverse debugging option, but I noticed that it was not possible to check the m_reverseToolButton. 
I believe this PR might solve the issue. 
Regards

Davide